### PR TITLE
Removed Cassette, and just _always_ do the print transformation at parsetime!

### DIFF
--- a/ide/ide.jl
+++ b/ide/ide.jl
@@ -150,7 +150,7 @@ function editorchange(w, globalFilepath, editortext)
             # writes to the app. Perhaps in a different type of output div.
             UserCode = Module(:UserCode)
             setparent!(UserCode, UserCode)
-            outs = CassetteLive.liveEvalCassette(parsed, UserCode)
+            outs = LiveEval.liveEval(parsed, UserCode)
             for (l, v) in outs
                 if v === nothing continue end
                 outputlines[l] *= "$v "

--- a/test/evaluate.jl
+++ b/test/evaluate.jl
@@ -27,7 +27,6 @@ end)
      foo(3)
  end
 
-#_ctx = LiveEval.LiveCtx(metadata = LiveEval.CollectedOutputs([], []))
 @time eval(LiveEval.thunkwrap(quote
     function foo(x)
         if (x > 0)
@@ -43,7 +42,7 @@ end))
 LiveEval.ctx.outputs
 
 
-LiveEval.thunkwrap_toplevel(quote
+LiveEval.thunkwrap(quote
     function foo(x)
         if (x > 0)
             100
@@ -91,11 +90,7 @@ LiveEval.ctx.outputs
 end
 LiveEval.ctx.outputs
 
-3
-
-#_ctx = LiveEval.LiveCtx(metadata = LiveEval.CollectedOutputs([], []))
-#@time @eval LiveEval.Cassette.overdub($_ctx, ()->$(LiveEval.thunkwrap_toplevel(quote
-@time for toplevel_expr in LiveEval.thunkwrap_toplevel(quote
+@time for toplevel_expr in LiveEval.thunkwrap(quote
         module Test
         module M
             struct X end
@@ -139,3 +134,5 @@ foo
 dump(quote f() = 5 end)
 
 Core.eval(Main, quote Core.eval(Main, (()->quote f2(x) = x+1 end)()) end)
+
+liveEval(quote module M x = 6 end end)


### PR DESCRIPTION
The whole point of Cassette is to let you do runtime-controlled
rewrites of existing code, but since I get to parse it myself, I can
just insert whatever changes I want then, at parse-time!

This improves performance by like 10x. :)