### PR TITLE
Reimplement the `Live.@test` and `Live.@testfile` macros in the new system.

### DIFF
--- a/examples/example1.jl
+++ b/examples/example1.jl
@@ -1,20 +1,17 @@
 import Live
 Live.@script()
 
-Live.@test 
 function helloNathan()
    s = "Hello, World"
    nameindex = match(r"World", s).offset
    s[1:nameindex-1]*"Nathan"
 end
 
-helloNathan()
-
+Live.@test helloNathan()
 
 function notTested(x)
   return x + 1
 end
-notTested(10)
 
 NOT_DEFINED
 
@@ -25,8 +22,7 @@ else
   6
 end
 
-
-Live.@test 
+Live.@test foo()
 function foo()
   if true == false
     5
@@ -37,5 +33,5 @@ function foo()
   x = 3
   return x
 end
-    
+
 

--- a/examples/example1.jl
+++ b/examples/example1.jl
@@ -6,7 +6,6 @@ function helloNathan()
    nameindex = match(r"World", s).offset
    s[1:nameindex-1]*"Nathan"
 end
-
 Live.@test helloNathan()
 
 function notTested(x)

--- a/examples/selfTestedFile.jl
+++ b/examples/selfTestedFile.jl
@@ -1,22 +1,6 @@
 using Live
-Live.@script()
+Live.@testfile("$(homedir())/Documents/Live/examples/testedfile_test.jl")
 
-using Test
-
-# src/foo.jl
-
-Live.@testfile(@__FILE__)
 function foo(a,b)
    return (true,false)
 end
-
-# ----
-# tests/foo.jl
-
-Live.@tested(foo)
-Test.@testset "foo val" begin
- x = 1
- out = foo(x, x+1)
- Test.@test out[1] == true
-end
-

--- a/examples/selfTestedFile.jl
+++ b/examples/selfTestedFile.jl
@@ -1,6 +1,8 @@
 using Live
+
 Live.@testfile("$(homedir())/Documents/Live/examples/testedfile_test.jl")
 
-function foo(a,b)
+function foo1(a,b)
+   println("HI")
    return (true,false)
 end

--- a/examples/testedfile.jl
+++ b/examples/testedfile.jl
@@ -2,7 +2,14 @@ using Live
 
 Live.@testfile("$(homedir())/Documents/Live/examples/testedfile_test.jl")
 
-function foo1(a,b)
-   println("HI")
+function foo(a,b)
    return (true,false)
+end
+
+function foo1(a,b)
+	if a < b
+    	a + b
+    else
+        a - b
+    end
 end

--- a/examples/testedfile.jl
+++ b/examples/testedfile.jl
@@ -2,11 +2,11 @@ using Live
 
 Live.@testfile("$(homedir())/Documents/Live/examples/testedfile_test.jl")
 
-function foo(a,b)
-   return (true,false)
+function foo()
+   return (true, false)
 end
 
-function foo1(a,b)
+function foo1(a, b)
 	if a < b
     	a + b
     else

--- a/examples/testedfile_test.jl
+++ b/examples/testedfile_test.jl
@@ -1,0 +1,13 @@
+using Test
+#include("$(homedir())/Documents/Live/examples/selfTestedFile.jl")
+
+println("HI! Module: $(@__MODULE__)")
+
+@testset "foo" begin
+  Test.@test foo(2,3) == (true,false)
+end
+
+@testset "foo" begin
+  Test.@test foo1(2,3) == (true,false)
+  Test.@test foo1(3,3) == (true,false)
+end

--- a/examples/testedfile_test.jl
+++ b/examples/testedfile_test.jl
@@ -1,13 +1,11 @@
 using Test
-#include("$(homedir())/Documents/Live/examples/selfTestedFile.jl")
-
-println("HI! Module: $(@__MODULE__)")
+#include("$(homedir())/Documents/Live/examples/testedfile.jl")
 
 @testset "foo" begin
-  Test.@test foo(2,3) == (true,false)
+  Test.@test foo() == (true,false)
 end
 
-@testset "foo" begin
-  Test.@test foo1(2,3) == (true,false)
-  Test.@test foo1(3,3) == (true,false)
+@testset "foo1" begin
+  Test.@test foo1(2, 3) == 5
+  Test.@test foo1(3, 3) == 0
 end

--- a/ide/ide.jl
+++ b/ide/ide.jl
@@ -14,7 +14,6 @@ Live.@script(false)
 
 include("parsefile.jl")
 include("evaluate.jl")
-include("live.jl")
 
 global bg_window = nothing
 function new_window()

--- a/ide/ide.jl
+++ b/ide/ide.jl
@@ -14,6 +14,7 @@ Live.@script(false)
 
 include("parsefile.jl")
 include("evaluate.jl")
+include("live.jl")
 
 global bg_window = nothing
 function new_window()
@@ -134,9 +135,6 @@ function setOutputText(linesdict, line, text)
     end
 end
 
-is_function_testline_request(_) = false
-is_function_testline_request(_::Live.TestLine) = true
-
 function editorchange(w, globalFilepath, editortext)
     #try  # So errors don't crash my Blink window...
         outputlines = DefaultDict{Int,String}("")
@@ -149,6 +147,9 @@ function editorchange(w, globalFilepath, editortext)
             # TODO: ooh, we should also probably swipe stdout so that it also
             # writes to the app. Perhaps in a different type of output div.
             UserCode = Module(:UserCode)
+            @eval UserCode import Base: eval
+            #@eval UserCode include(fname::AbstractString) = Main.Base.include(@__MODULE__, Base.relpath(fname, @__FILE__))
+            @eval UserCode include(fname::AbstractString) = Main.Base.include(@__MODULE__, fname)
             setparent!(UserCode, UserCode)
             outs = LiveEval.liveEval(parsed, UserCode)
             for (l, v) in outs

--- a/ide/live.jl
+++ b/ide/live.jl
@@ -4,7 +4,7 @@
     end
 
     # Run the function!
-    function testcall(fcall, linenode)
+    function testcall(fcall, linenode::$LiveIDEFile)
         quote
             function live_test()
                 $(esc(fcall))
@@ -15,19 +15,19 @@
     end
 
     # Include the testfile
-    function testfile_call(files)
+    function testfile_call(files, linenode::$LiveIDEFile)
         escfiles = [esc(f) for f in files]
         quote
             for f in [$(escfiles...)]
-                push!(Live.testthunks, ()->begin
+                push!($Live.testthunks, ()->begin
                  @show f
-                 include(f); nothing end)
+                 (@__MODULE__).include(f); nothing end)
             end
         end
     end
 
     # Toggle script mode
-    function script_call(enable)
+    function script_call(enable, linenode::$LiveIDEFile)
         # TODO
     end
 end

--- a/ide/live.jl
+++ b/ide/live.jl
@@ -1,0 +1,33 @@
+@eval Live begin
+    function reset_testfuncs()
+        global testthunks = Function[]
+    end
+
+    # Run the function!
+    function testcall(fcall, linenode)
+        quote
+            function live_test()
+                $(esc(fcall))
+            end
+            push!($Live.testthunks, live_test)
+            nothing
+        end
+    end
+
+    # Include the testfile
+    function testfile_call(files)
+        escfiles = [esc(f) for f in files]
+        quote
+            for f in [$(escfiles...)]
+                push!(Live.testthunks, ()->begin
+                 @show f
+                 include(f); nothing end)
+            end
+        end
+    end
+
+    # Toggle script mode
+    function script_call(enable)
+        # TODO
+    end
+end

--- a/src/Live.jl
+++ b/src/Live.jl
@@ -21,14 +21,10 @@ Live.@test foo(5, zeros(3))
 ```
 """
 macro test(fcall)
-    testcall(fcall, __source__.file)
+    testcall(fcall, __source__.file, __source__.line)
 end
 # Do nothing by default
-function testcall(fcall, linenode)
-    @show fcall
-    @show linenode
-    nothing
-end
+function testcall(fcall, file, line) end
 
 """
     Live.@testfile(testfile)
@@ -62,9 +58,9 @@ end
 ```
 """
 macro testfile(files...)
-    testfile_call(files, __source__.file)
+    testfile_call(files, __source__.file, __source__.line)
 end
-function testfile_call(files, linenode) end
+function testfile_call(files, file, line) end
 
 
 """
@@ -74,8 +70,8 @@ Enable script-mode in the LiveIDE, causing it to display live output for each
 subsequent line of this file. Calling `Live.script(false)` will disable output.
 """
 macro script(enable=true)
-    script_call(enable, __source__.file)
+    script_call(enable, __source__.file, __source__.line)
 end
-function script_call(enable, linenode) end
+function script_call(enable, file, line) end
 
 end

--- a/src/Live.jl
+++ b/src/Live.jl
@@ -6,45 +6,25 @@
 module Live
 
 """
-    Live.@script(enable=true)
-
-Enable script-mode in the LiveIDE, causing it to display live output for each
-subsequent line of this file. Calling `Live.script(false)` will disable output.
-"""
-macro script(enable=true)
-    ScriptLine(enable)
-end
-# This struct tells LiveIDE to enable/disable script-mode.
-struct ScriptLine
-    enabled::Bool
-end
-
-"""
     Live.@test
 
 This is the main interface for Live: Live.@test
-Use it to test a function in the LiveIDE by annotating the function with this
-macro on its own line:
+Use it to test a function in the LiveIDE. Can be written anywhere.
 
 ```julia
 using Live
 
-Live.@test a=5 b=zeros(3)
 function foo(a,b)
     # ...
 end
+Live.@test foo(5, zeros(3))
 ```
 """
-macro test(args...)
-    TestLine(args, __source__)
+macro test(fcall)
+    testcall(fcall, __source__)
 end
-
-# This struct is used by the IDE to pass a context (args) into a function when
-# executing it via Live.@test
-struct TestLine
-    args
-    lineNode::LineNumberNode
-end
+# Do nothing by default
+function testcall(fcall, linenode) end
 
 """
     Live.@testfile(testfile)
@@ -78,52 +58,20 @@ end
 ```
 """
 macro testfile(files...)
-    TestFileLine(files, __source__)
+    testfile_call(files)
 end
+function testfile_call(files) end
 
-struct TestFileLine
-    files
-    lineNode::LineNumberNode
-end
 
 """
-    Live.@tested(functionname)
+    Live.@script(enable=true)
 
-Record a @test's or @testset's calls to `functionname` for testing that function
-in LiveIDE.
-
-If the provided function (`functionname`) is annotated with a `Live.@testfile`
-that includes this test file, then any time that function is invoked from this
-@test or @testset, the parameters passed to that function will be available as
-inputs for live debug output in the LiveIDE where that function is defined.
-
-See also Live.@testfile.
-
-```julia
-# src/foo.jl
-
-Live.@testfile("../tests/foo.jl")
-function foo(a,b)
-    # ...
-end
-
-# ----
-# tests/foo.jl
-
-Live.@tested(foo)
-@testset "foo val" begin
- x = 1
- out = foo(x, x+1)
- @test out.val == true
-end
-```
+Enable script-mode in the LiveIDE, causing it to display live output for each
+subsequent line of this file. Calling `Live.script(false)` will disable output.
 """
-macro tested(functionname)
-    TestedLine(functionname)
+macro script(enable=true)
+    script_call(enable)
 end
-
-struct TestedLine
-    functionname
-end
+function script_call(enable) end
 
 end

--- a/src/Live.jl
+++ b/src/Live.jl
@@ -21,10 +21,14 @@ Live.@test foo(5, zeros(3))
 ```
 """
 macro test(fcall)
-    testcall(fcall, __source__)
+    testcall(fcall, __source__.file)
 end
 # Do nothing by default
-function testcall(fcall, linenode) end
+function testcall(fcall, linenode)
+    @show fcall
+    @show linenode
+    nothing
+end
 
 """
     Live.@testfile(testfile)
@@ -58,9 +62,9 @@ end
 ```
 """
 macro testfile(files...)
-    testfile_call(files)
+    testfile_call(files, __source__.file)
 end
-function testfile_call(files) end
+function testfile_call(files, linenode) end
 
 
 """
@@ -70,8 +74,8 @@ Enable script-mode in the LiveIDE, causing it to display live output for each
 subsequent line of this file. Calling `Live.script(false)` will disable output.
 """
 macro script(enable=true)
-    script_call(enable)
+    script_call(enable, __source__.file)
 end
-function script_call(enable) end
+function script_call(enable, linenode) end
 
 end


### PR DESCRIPTION
Allows support for `Live.@test` and `Live.@testfile` macros that _actually_ do what I wanted this time! And it was _so much easier_!! :)

I still need to do `Live.@script`. Currently that's effectively always set to `true`.